### PR TITLE
RB-491 Min/Max trackers do not reset internal state on reset

### DIFF
--- a/libs/std/include/rtbot/std/MinMaxTracker.h
+++ b/libs/std/include/rtbot/std/MinMaxTracker.h
@@ -24,6 +24,11 @@ class MinTracker : public Operator {
   std::string type_name() const override { return "MinTracker"; }
   double get_current_min() const { return min_; }
 
+  void reset() override {
+    Operator::reset();
+    min_ = std::numeric_limits<double>::infinity();
+  }
+
   bool equals(const MinTracker& other) const {
     return StateSerializer::hash_double(min_) ==
                StateSerializer::hash_double(other.min_) &&
@@ -94,6 +99,11 @@ class MaxTracker : public Operator {
 
   std::string type_name() const override { return "MaxTracker"; }
   double get_current_max() const { return max_; }
+
+  void reset() override {
+    Operator::reset();
+    max_ = -std::numeric_limits<double>::infinity();
+  }
 
   bool equals(const MaxTracker& other) const {
     return StateSerializer::hash_double(max_) ==

--- a/libs/std/test/test_min_max_tracker.cpp
+++ b/libs/std/test/test_min_max_tracker.cpp
@@ -134,6 +134,60 @@ SCENARIO("MinTracker serialization roundtrip", "[min_max_tracker][State]") {
   }
 }
 
+SCENARIO("MinTracker.reset re-initializes accumulator", "[min_max_tracker]") {
+  SECTION("After reset, the next message becomes the new min") {
+    auto mn = make_min_tracker("mn1");
+    auto col = std::make_shared<Collector>("c", std::vector<std::string>{"number"});
+    mn->connect(col, 0, 0);
+
+    // Establish a running min of 3 over [5,3,7].
+    mn->receive_data(create_message<NumberData>(1, NumberData{5.0}), 0);
+    mn->receive_data(create_message<NumberData>(2, NumberData{3.0}), 0);
+    mn->receive_data(create_message<NumberData>(3, NumberData{7.0}), 0);
+    mn->execute();
+    REQUIRE(mn->get_current_min() == Approx(3.0));
+
+    mn->reset();
+    REQUIRE(mn->get_current_min() == std::numeric_limits<double>::infinity());
+
+    // After reset, a value larger than the previous min must be reported,
+    // not clamped by leftover state.
+    mn->receive_data(create_message<NumberData>(4, NumberData{42.0}), 0);
+    mn->execute();
+    REQUIRE(mn->get_current_min() == Approx(42.0));
+    auto& out = col->get_data_queue(0);
+    const auto* last = dynamic_cast<const Message<NumberData>*>(out.back().get());
+    REQUIRE(last->data.value == Approx(42.0));
+  }
+}
+
+SCENARIO("MaxTracker.reset re-initializes accumulator", "[min_max_tracker]") {
+  SECTION("After reset, the next message becomes the new max") {
+    auto mx = make_max_tracker("mx1");
+    auto col = std::make_shared<Collector>("c", std::vector<std::string>{"number"});
+    mx->connect(col, 0, 0);
+
+    // Establish a running max of 7 over [5,3,7].
+    mx->receive_data(create_message<NumberData>(1, NumberData{5.0}), 0);
+    mx->receive_data(create_message<NumberData>(2, NumberData{3.0}), 0);
+    mx->receive_data(create_message<NumberData>(3, NumberData{7.0}), 0);
+    mx->execute();
+    REQUIRE(mx->get_current_max() == Approx(7.0));
+
+    mx->reset();
+    REQUIRE(mx->get_current_max() == -std::numeric_limits<double>::infinity());
+
+    // After reset, a value smaller than the previous max must be reported,
+    // not held back by leftover state.
+    mx->receive_data(create_message<NumberData>(4, NumberData{2.0}), 0);
+    mx->execute();
+    REQUIRE(mx->get_current_max() == Approx(2.0));
+    auto& out = col->get_data_queue(0);
+    const auto* last = dynamic_cast<const Message<NumberData>*>(out.back().get());
+    REQUIRE(last->data.value == Approx(2.0));
+  }
+}
+
 SCENARIO("MaxTracker serialization roundtrip", "[min_max_tracker][State]") {
   SECTION("Collect and restore mid-stream") {
     auto mx = make_max_tracker("mx1");

--- a/libs/std/test/test_pipeline.cpp
+++ b/libs/std/test/test_pipeline.cpp
@@ -7,6 +7,7 @@
 #include "rtbot/std/CumulativeSum.h"
 #include "rtbot/std/Count.h"
 #include "rtbot/fuse/FusedExpression.h"
+#include "rtbot/std/MinMaxTracker.h"
 #include "rtbot/std/MovingAverage.h"
 #include "rtbot/std/PeakDetector.h"
 #include "rtbot/std/VectorExtract.h"
@@ -608,6 +609,88 @@ SCENARIO("Pipeline: reset with MovingAverage restarts accumulation", "[pipeline]
         const auto* msg = dynamic_cast<const Message<NumberData>*>(output[0].get());
         REQUIRE(msg->time == 5);
         REQUIRE(msg->data.value == Approx(15.0));  // Average of 10.0 and 20.0
+      }
+    }
+  }
+}
+
+SCENARIO("Pipeline: per-segment Min/Max reset on key change", "[pipeline][reset][min_max_tracker]") {
+  // Regression for RB-491. MinTracker/MaxTracker previously had no reset()
+  // override, so their internal accumulators carried the running min/max
+  // across segment boundaries instead of restarting per segment.
+
+  GIVEN("A pipeline with MaxTracker inside") {
+    auto pipeline = std::make_unique<Pipeline>(
+        "max_pipe",
+        std::vector<std::string>{PortType::NUMBER},
+        std::vector<std::string>{PortType::NUMBER});
+    auto col = std::make_shared<Collector>("c", std::vector<std::string>{"number"});
+    pipeline->connect(col, 0, 0);
+
+    auto mx = std::make_shared<MaxTracker>("mx");
+    pipeline->register_operator(mx);
+    pipeline->set_entry("mx");
+    pipeline->add_output_mapping("mx", 0, 0);
+
+    WHEN("Two segments where the second contains only smaller values") {
+      // Segment 1 (key=1): values [10, 20, 90] → running max = 90.
+      send_paired(*pipeline, 1, 10.0, 1.0);
+      send_paired(*pipeline, 2, 20.0, 1.0);
+      send_paired(*pipeline, 3, 90.0, 1.0);
+
+      // Key change → emit segment 1's last buffered max (=90) at boundary t=4.
+      send_paired(*pipeline, 4, 30.0, 0.0);
+      // Segment 2 (key=0): values [30, 20] → per-segment max should be 30.
+      send_paired(*pipeline, 5, 20.0, 0.0);
+
+      // Final key change → emit segment 2's max at boundary t=6.
+      send_paired(*pipeline, 6, 0.0, 1.0);
+
+      THEN("Each emission reflects per-segment max, not running max across segments") {
+        const auto& output = col->get_data_queue(0);
+        REQUIRE(output.size() == 2);
+        REQUIRE(dynamic_cast<const Message<NumberData>*>(output[0].get())->data.value
+                == Approx(90.0));
+        REQUIRE(dynamic_cast<const Message<NumberData>*>(output[1].get())->data.value
+                == Approx(30.0));
+      }
+    }
+  }
+
+  GIVEN("A pipeline with MinTracker inside") {
+    auto pipeline = std::make_unique<Pipeline>(
+        "min_pipe",
+        std::vector<std::string>{PortType::NUMBER},
+        std::vector<std::string>{PortType::NUMBER});
+    auto col = std::make_shared<Collector>("c", std::vector<std::string>{"number"});
+    pipeline->connect(col, 0, 0);
+
+    auto mn = std::make_shared<MinTracker>("mn");
+    pipeline->register_operator(mn);
+    pipeline->set_entry("mn");
+    pipeline->add_output_mapping("mn", 0, 0);
+
+    WHEN("Two segments where the second contains only larger values") {
+      // Segment 1 (key=1): values [50, 10, 30] → running min = 10.
+      send_paired(*pipeline, 1, 50.0, 1.0);
+      send_paired(*pipeline, 2, 10.0, 1.0);
+      send_paired(*pipeline, 3, 30.0, 1.0);
+
+      // Key change → emit segment 1's min (=10) at t=4.
+      send_paired(*pipeline, 4, 60.0, 0.0);
+      // Segment 2 (key=0): values [60, 75] → per-segment min should be 60.
+      send_paired(*pipeline, 5, 75.0, 0.0);
+
+      // Final key change → emit segment 2's min at t=6.
+      send_paired(*pipeline, 6, 0.0, 1.0);
+
+      THEN("Each emission reflects per-segment min, not running min across segments") {
+        const auto& output = col->get_data_queue(0);
+        REQUIRE(output.size() == 2);
+        REQUIRE(dynamic_cast<const Message<NumberData>*>(output[0].get())->data.value
+                == Approx(10.0));
+        REQUIRE(dynamic_cast<const Message<NumberData>*>(output[1].get())->data.value
+                == Approx(60.0));
       }
     }
   }


### PR DESCRIPTION
## Summary

`MinTracker` and `MaxTracker` initialize their accumulators (`min_ = +inf`, `max_ = -inf`) only in the constructor and never override `reset()`. When `Pipeline::reset_internals()` runs at a segment boundary it calls `op->reset()` on every prototype operator, but for these two the accumulator is left untouched, so the running min/max persists into the next segment.

`SUM` and `COUNT` were unaffected (their operators already override `reset()`). `MAX(TS())` looked correct because `TS()` is monotonic. Fused-path MIN_AGG/MAX_AGG were also unaffected — the bug only surfaces when standalone trackers run inside a Pipeline prototype (e.g. rtbot-sql's pure-segment GROUP BY).

## Test plan

- [x] `bazel test //libs/std/test:test`
- [x] `bazel test //libs/api/test:test //libs/core/test:test //libs/fuse/test:test`